### PR TITLE
API for retrieving per-opponent standings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:client": "browserify src/app-client.js -o dist/static/app-client.js && node-sass --importer ./node_modules/frau-sass-importer/ src/app-client.scss dist/static/app-client.css",
     "build": "npm run build:client",
     "start:build": "npm run build",
-    "start:executeLocal": "nodemon -- ./node_modules/babel-cli/bin/babel-node.js ./dist/app-server.js",
+    "start:executeLocal": "npm run build && nodemon -- ./node_modules/babel-cli/bin/babel-node.js ./dist/app-server.js",
     "start:execute": "node_modules/babel-cli/bin/babel-node.js dist/app-server.js",
     "start": "npm run start:build && npm run start:execute",
     "startLocal": "npm run start:build && npm run start:executeLocal",

--- a/src/api/standings.js
+++ b/src/api/standings.js
@@ -22,6 +22,22 @@ class Standings {
 			records: result.rows
 		};
 	}
+
+	static *perOpponent(player) {
+		const query = `SELECT player
+							, opponent
+							, home_wins
+							, away_wins
+							, home_losses
+							, away_losses
+							, total_wins
+							, total_losses
+						FROM getStandingsPerOpponent('${player}')`;
+		const result = yield this.pg.db.client.query_(query);
+		this.body = {
+			records: result.rows
+		};
+	}
 }
 
 export default Standings;

--- a/src/app-client.js
+++ b/src/app-client.js
@@ -4,15 +4,16 @@ import { Router, Route, IndexRoute, browserHistory } from 'react-router';
 import Home from './components/home';
 import MatchResults from './components/matches/index';
 import AddMatchResult from './components/matches/add';
+import Player from './components/players/index';
 
 const parentElement = document.getElementById('placeholder');
-// const orgUnitId = parentElement.getAttribute('data-org-unit-id');
 
 ReactDOM.render((
 	<Router history={browserHistory}>
 	  <Route path="/" component={Home} />
 	  <Route path="/matches" component={MatchResults} />
 	  <Route path="/matches/add" component={AddMatchResult} />
+	  <Route path="/players/:name" component={Player} />
 	</Router>),
 	document.getElementById('placeholder')
 );

--- a/src/app-server.js
+++ b/src/app-server.js
@@ -26,6 +26,7 @@ app.use(pg({
 }));
 
 app.use(route.get('/api/standings/', Standings.list));
+app.use(route.get('/api/standings/:player', Standings.perOpponent));
 app.use(route.get('/api/matches/', Matches.list));
 app.use(route.post('/api/matches/', Matches.add));
 app.use(route.get('/api/awards/', Awards.list));

--- a/src/components/players/index.js
+++ b/src/components/players/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import StandingsPerOpponent from '../standings/perOpponent/index';
+
+class Player extends React.Component
+{
+	constructor(props) {
+		super(props);
+		this.state = { data: null };
+	}
+
+	render() {
+		const title = `${this.props.params.name}'s Page`;
+		return (
+			<div>
+				<h1>{title}</h1>
+				<StandingsPerOpponent {...this.props} />
+			</div>
+		);
+	}
+}
+
+export default Player;

--- a/src/components/standings/perOpponent/index.js
+++ b/src/components/standings/perOpponent/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import StandingsTable from './table';
+import request from 'superagent';
+import { promisify } from '../../../lib/promisify';
+
+class StandingsPerOpponent extends React.Component
+{
+	constructor(props) {
+		super(props);
+		this.state = { data: null };
+	}
+
+	componentWillMount() {
+		const self = this;
+
+		request.get(`/api/standings/${this.props.params.name}`)
+				.use(promisify)
+				.promise()
+				.then(function(response) {
+					self.setState({ data: response.body });
+				});
+	}
+
+	render() {
+		return (
+			<div>
+				<StandingsTable data={this.state.data} />
+			</div>
+		);
+	}
+}
+
+export default StandingsPerOpponent;

--- a/src/components/standings/perOpponent/record.js
+++ b/src/components/standings/perOpponent/record.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class Record extends React.Component {
+	render() {
+		const data = this.props.data,
+				wins = data.total_wins,
+				losses = data.total_losses,
+				games_played = +data.total_wins + +data.total_losses;
+
+		return (
+			<tr>
+				<td>{data.opponent}</td>
+				<td>{games_played}</td>
+				<td>{wins}</td>
+				<td>{losses}</td>
+			</tr>
+		);
+	}
+}
+
+export default Record;

--- a/src/components/standings/perOpponent/table.js
+++ b/src/components/standings/perOpponent/table.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'react-router';
+import Record from './record';
+
+class StandingsPerOpponentTable extends React.Component {
+
+	constructor(props) {
+	  super(props);
+	  this.state = {};
+	}
+
+	render() {
+		let data = this.props.data;
+
+		if (!data || !data.records) {
+			return <div><p>loading...</p></div>;
+		}
+
+		if (data.records.length < 1) {
+			return (
+				<div>
+					<h2>No per-opponent standings to display</h2>
+					<p>You know nothing, {this.props.params.name}. Play the game of thr--- uhh, table hockey, then <Link to="matches/add">add some results</Link>.</p>
+				</div>
+			);
+		}
+
+		console.log('records are ', data.records);
+
+		return (
+			<div>
+				<table summary="Wins, losses, and other overall summary data related to player vs player matches">
+					<caption>Per Opponent Standings</caption>
+					<thead>
+						<tr>
+							<th>Opponent</th>
+							<th>GP</th>
+							<th>Wins</th>
+							<th>Losses</th>
+						</tr>
+					</thead>
+					<tbody>
+					{
+						data.records.map((record, index) => {
+							return <Record key={index} data={record} />;
+						})
+					}
+					</tbody>
+				</table>
+			</div>
+		);
+	}
+}
+
+export default StandingsPerOpponentTable;

--- a/src/components/standings/record.js
+++ b/src/components/standings/record.js
@@ -1,21 +1,24 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 class Record extends React.Component {
 	render() {
-
-		const gfpg = this.props.data.total_goals_for / this.props.data.games_played;
-		const gapg = this.props.data.total_goals_against / this.props.data.games_played;
+		const data = this.props.data;
+		const gfpg = data.total_goals_for / data.games_played;
+		const gapg = data.total_goals_against / data.games_played;
+		const player = data.player;
+		const playerUrl = `players/${player}`;
 
 		return (
 			<tr>
-				<td>{this.props.data.player}</td>
-				<td>{this.props.data.games_played}</td>
-				<td>{this.props.data.wins}</td>
-				<td>{this.props.data.losses}</td>
-				<td className='detailed-info'>{this.props.data.win_percentage}</td>
+				<td><Link to={playerUrl}>{player}</Link></td>
+				<td>{data.games_played}</td>
+				<td>{data.wins}</td>
+				<td>{data.losses}</td>
+				<td className='detailed-info'>{data.win_percentage}</td>
 				<td className='detailed-info'>{gfpg.toFixed(2)}</td>
 				<td className='detailed-info'>{gapg.toFixed(2)}</td>
-				<td className='detailed-info'>{this.props.data.total_goals_diff}</td>
+				<td className='detailed-info'>{data.total_goals_diff}</td>
 			</tr>
 		);
 	}

--- a/src/views/home.html
+++ b/src/views/home.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="/static/app-client.css" />
   </head>
   <body>
-    <!-- <div id="placeholder" data-org-unit-id="{{orgUnitId}}"></div> -->
 	<div id="placeholder"></div>
     <script src="/static/app-client.js"></script>
   </body>


### PR DESCRIPTION
This is mostly database work, creating a function that can retrieve the per-opponent win/loss results for a given player. The API then simply exposes this via /api/standings/:player .

Subsequently added a basic player page with a table for displaying the per opponent standings. Link to it from the main standings table.

This work is towards fulfilling feature #9 
